### PR TITLE
Fix 4.5.17 support

### DIFF
--- a/DOL_Loader/DOLLoader.m
+++ b/DOL_Loader/DOLLoader.m
@@ -72,6 +72,11 @@ static void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
     return @"dol";
 }
 
+
+- (NSArray<NSString *> *)commandLineIdentifiers {
+    return @[@"dol"];
+}
+
 - (CPUEndianess)endianess {
     return CPUEndianess_Big;
 }

--- a/PPCCPU/PPCCPU.m
+++ b/PPCCPU/PPCCPU.m
@@ -85,8 +85,12 @@ static void OSWriteBigInt32(void *address, uintptr_t offset, int32_t data) {
     return @"0.0.2";
 }
 
-- (NSString *)commandLineIdentifier {
+- (NSString *) commandLineIdentifier {
     return @"ppc32";
+}
+
+- (NSArray<NSString *> *) commandLineIdentifiers {
+    return @[@"ppc32"];
 }
 
 - (NSArray *)cpuSubFamiliesForFamily:(NSString *)family {

--- a/REL_Linker/RELLinker.m
+++ b/REL_Linker/RELLinker.m
@@ -534,4 +534,8 @@ struct rel_relocation_entry
     return @"RelLinker";
 }
 
+- (NSArray<NSString *> *)commandLineIdentifiers {
+    return @[@"RelLinker"];
+}
+
 @end


### PR DESCRIPTION
4.5.17 changed how `commandLineIdentifier` works, it now returns an `NSArray` of `NSString` and the symbol has been updated to match the new behavior.